### PR TITLE
Add Quad/Vertex structs for packed data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["meshing", "greedy", "binary", "voxel", "chunk"]
 [dependencies]
 
 [dev-dependencies]
-bevy = "0.16"
-criterion = "0.5"
+bevy = "0.16.1"
+criterion = "0.6"
 
 [[bench]]
 name = "mesh"

--- a/examples/sphere.rs
+++ b/examples/sphere.rs
@@ -18,7 +18,6 @@ pub const ATTRIBUTE_VOXEL_DATA: MeshVertexAttribute =
 
 const SIZE: usize = 16;
 const SIZE2: usize = SIZE.pow(2);
-const MASK6: u32 = 0b111_111;
 
 fn main() {
     App::new()
@@ -90,10 +89,8 @@ fn generate_mesh() -> Mesh {
         let n = face.n();
         for quad in quads {
             let vertices_packed = face.vertices_packed(*quad);
-            for vertex_packed in vertices_packed.iter() {
-                let x = *vertex_packed & MASK6;
-                let y = (*vertex_packed >> 6) & MASK6;
-                let z = (*vertex_packed >> 12) & MASK6;
+            for vertex in vertices_packed.iter() {
+                let [x, y, z] = vertex.xyz();
                 positions.push([x as f32, y as f32, z as f32]);
                 normals.push(n.clone());
             }

--- a/examples/transparency.rs
+++ b/examples/transparency.rs
@@ -18,7 +18,6 @@ pub const ATTRIBUTE_VOXEL_DATA: MeshVertexAttribute =
 
 const LAYER_W: usize = 3;
 const SIZE: usize = 10;
-const MASK6: u32 = 0b111_111;
 
 fn main() {
     App::new()
@@ -127,12 +126,10 @@ fn generate_meshes() -> [Mesh; 3] {
         let face: bgm::Face = (face_n as u8).into();
         let n = face.n();
         for &quad in quads {
-            let voxel_i = (quad >> 32) as usize - 1;
+            let voxel_i = quad.voxel_id() as usize - 1;
             let vertices_packed = face.vertices_packed(quad);
-            for &vertex_packed in vertices_packed.iter() {
-                let x = vertex_packed & MASK6;
-                let y = (vertex_packed >> 6) & MASK6;
-                let z = (vertex_packed >> 12) & MASK6;
+            for &vertex in vertices_packed.iter() {
+                let [x, y, z] = vertex.xyz();
                 positions[voxel_i].push([x as f32, y as f32, z as f32]);
                 normals[voxel_i].push(n.clone());
             }

--- a/src/face.rs
+++ b/src/face.rs
@@ -1,4 +1,4 @@
-use crate::MASK_6;
+use crate::Quad;
 
 const MASK_XYZ: u64 = 0b111111_111111_111111;
 
@@ -27,12 +27,47 @@ impl From<u8> for Face {
     }
 }
 
-fn packed_xyz(x: u32, y: u32, z: u32) -> u32 {
-    (z << 12) | (y << 6) | x
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Vertex(pub u32);
+
+impl Vertex {
+    const MASK_6: u32 = 0b111111;
+
+    pub fn new() -> Self {
+        Self(0u32)
+    }
+
+    pub fn pack(xyz: u32, u: u32, v: u32) -> Self {
+        Self((v << 24) | (u << 18) | xyz)
+    }
+
+    pub fn x(&self) -> u32 {
+        self.0 & Vertex::MASK_6
+    }
+
+    pub fn y(&self) -> u32 {
+        (self.0 >> 6) & Vertex::MASK_6
+    }
+
+    pub fn z(&self) -> u32 {
+        (self.0 >> 12) & Vertex::MASK_6
+    }
+
+    pub fn u(&self) -> u32 {
+        (self.0 >> 18) & Vertex::MASK_6
+    }
+
+    pub fn v(&self) -> u32 {
+        (self.0 >> 24) & Vertex::MASK_6
+    }
+
+    pub fn xyz(&self) -> [u32; 3] {
+        [self.x(), self.y(), self.z()]
+    }
 }
 
-fn vertex_info(xyz: u32, u: u32, v: u32) -> u32 {
-    (v << 24) | (u << 18) | xyz
+fn packed_xyz(x: u32, y: u32, z: u32) -> u32 {
+    (z << 12) | (y << 6) | x
 }
 
 impl Face {
@@ -49,46 +84,46 @@ impl Face {
 
     /// Takes a quad as outputted by binary greedy meshing, and outputs 4 vertices encoded as:
     /// (v << 24) | (u << 18) | (z << 12) | (y << 6) | x
-    pub fn vertices_packed(&self, quad: u64) -> [u32; 4] {
-        let w = (MASK_6 & (quad >> 18)) as u32;
-        let h = (MASK_6 & (quad >> 24)) as u32;
-        let xyz = (MASK_XYZ & quad) as u32;
+    pub fn vertices_packed(&self, quad: Quad) -> [Vertex; 4] {
+        let w = quad.width() as u32;
+        let h = quad.height() as u32;
+        let xyz = (MASK_XYZ & quad.0) as u32;
         match self {
             Face::Left => [
-                vertex_info(xyz, h, w),
-                vertex_info(xyz + packed_xyz(0, 0, h), 0, w),
-                vertex_info(xyz + packed_xyz(0, w, 0), h, 0),
-                vertex_info(xyz + packed_xyz(0, w, h), 0, 0),
+                Vertex::pack(xyz, h, w),
+                Vertex::pack(xyz + packed_xyz(0, 0, h), 0, w),
+                Vertex::pack(xyz + packed_xyz(0, w, 0), h, 0),
+                Vertex::pack(xyz + packed_xyz(0, w, h), 0, 0),
             ],
             Face::Down => [
-                vertex_info(xyz - packed_xyz(w, 0, 0) + packed_xyz(0, 0, h), w, h),
-                vertex_info(xyz - packed_xyz(w, 0, 0), w, 0),
-                vertex_info(xyz + packed_xyz(0, 0, h), 0, h),
-                vertex_info(xyz, 0, 0),
+                Vertex::pack(xyz - packed_xyz(w, 0, 0) + packed_xyz(0, 0, h), w, h),
+                Vertex::pack(xyz - packed_xyz(w, 0, 0), w, 0),
+                Vertex::pack(xyz + packed_xyz(0, 0, h), 0, h),
+                Vertex::pack(xyz, 0, 0),
             ],
             Face::Back => [
-                vertex_info(xyz, w, h),
-                vertex_info(xyz + packed_xyz(0, h, 0), w, 0),
-                vertex_info(xyz + packed_xyz(w, 0, 0), 0, h),
-                vertex_info(xyz + packed_xyz(w, h, 0), 0, 0),
+                Vertex::pack(xyz, w, h),
+                Vertex::pack(xyz + packed_xyz(0, h, 0), w, 0),
+                Vertex::pack(xyz + packed_xyz(w, 0, 0), 0, h),
+                Vertex::pack(xyz + packed_xyz(w, h, 0), 0, 0),
             ],
             Face::Right => [
-                vertex_info(xyz, 0, 0),
-                vertex_info(xyz + packed_xyz(0, 0, h), h, 0),
-                vertex_info(xyz - packed_xyz(0, w, 0), 0, w),
-                vertex_info(xyz + packed_xyz(0, 0, h) - packed_xyz(0, w, 0), h, w),
+                Vertex::pack(xyz, 0, 0),
+                Vertex::pack(xyz + packed_xyz(0, 0, h), h, 0),
+                Vertex::pack(xyz - packed_xyz(0, w, 0), 0, w),
+                Vertex::pack(xyz + packed_xyz(0, 0, h) - packed_xyz(0, w, 0), h, w),
             ],
             Face::Up => [
-                vertex_info(xyz + packed_xyz(w, 0, h), w, h),
-                vertex_info(xyz + packed_xyz(w, 0, 0), w, 0),
-                vertex_info(xyz + packed_xyz(0, 0, h), 0, h),
-                vertex_info(xyz, 0, 0),
+                Vertex::pack(xyz + packed_xyz(w, 0, h), w, h),
+                Vertex::pack(xyz + packed_xyz(w, 0, 0), w, 0),
+                Vertex::pack(xyz + packed_xyz(0, 0, h), 0, h),
+                Vertex::pack(xyz, 0, 0),
             ],
             Face::Front => [
-                vertex_info(xyz - packed_xyz(w, 0, 0) + packed_xyz(0, h, 0), 0, 0),
-                vertex_info(xyz - packed_xyz(w, 0, 0), 0, h),
-                vertex_info(xyz + packed_xyz(0, h, 0), w, 0),
-                vertex_info(xyz, w, h),
+                Vertex::pack(xyz - packed_xyz(w, 0, 0) + packed_xyz(0, h, 0), 0, 0),
+                Vertex::pack(xyz - packed_xyz(w, 0, 0), 0, h),
+                Vertex::pack(xyz + packed_xyz(0, h, 0), w, 0),
+                Vertex::pack(xyz, w, h),
             ],
         }
     }

--- a/src/quad.rs
+++ b/src/quad.rs
@@ -1,0 +1,76 @@
+use alloc::string::String;
+
+pub(crate) const MASK_6: u64 = 0b111111;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Quad(pub u64);
+
+impl Quad {
+    /// x: 6 bits
+    /// y: 6 bits
+    /// z: 6 bits 18
+    /// width (w): 6 bits
+    /// height (h): 6 bits
+    /// voxel id (v): 32 bits
+    ///
+    /// ao (a): 2 bits
+    ///
+    /// layout:
+    /// 0bvvvv_vvvv_vvvv_vvvv_vvvv_vvvv_vvvv_vvvv_00hh_hhhh_wwww_wwzz_zzzz_yyyy_yyxx_xxxx
+    #[inline]
+    pub fn pack(x: usize, y: usize, z: usize, w: usize, h: usize, v_type: usize) -> Self {
+        Quad(((v_type << 32) | (h << 24) | (w << 18) | (z << 12) | (y << 6) | x) as u64)
+    }
+
+    #[inline]
+    pub fn xyz(&self) -> [u64; 3] {
+        let x = (self.0) & MASK_6;
+        let y = (self.0 >> 6) & MASK_6;
+        let z = (self.0 >> 12) & MASK_6;
+        [x, y, z]
+    }
+
+    #[inline]
+    pub fn width(&self) -> u64 {
+        (self.0 >> 18) & MASK_6
+    }
+
+    #[inline]
+    pub fn height(&self) -> u64 {
+        (self.0 >> 24) & MASK_6
+    }
+
+    #[inline]
+    pub fn voxel_id(&self) -> u64 {
+        self.0 >> 32
+    }
+
+    /// Unpacks quad data and formats it as "{x};{y};{z} {w}x{h} v={v_type}" for debugging
+    #[inline]
+    pub fn debug_quad(&self) -> String {
+        let mut quad = self.0;
+        let x = quad & MASK_6;
+        quad >>= 6;
+        let y = quad & MASK_6;
+        quad >>= 6;
+        let z = quad & MASK_6;
+        quad >>= 6;
+        let w = quad & MASK_6;
+        quad >>= 6;
+        let h = quad & MASK_6;
+        quad >>= 8;
+        let v_type = quad;
+        format!("{x};{y};{z} {w}x{h} v={v_type}")
+    }
+}
+
+impl alloc::fmt::Debug for Quad {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Quad")
+            .field("position", &self.xyz())
+            .field("width", &self.width())
+            .field("height", &self.height())
+            .field("voxel_id", &self.voxel_id())
+            .finish()
+    }
+}


### PR DESCRIPTION
Simplify usage a bit so users don't have to unpack manually.

Might be worth splitting up lib.rs a little bit too, but can figure that out later.

TODO:
- Need to cut out the autoformatting nonsense
- Move the non-greedy mesh quad generation to a different PR